### PR TITLE
Per Tailwind's docs, base and components should not be purged.

### DIFF
--- a/lib/templates/tailwind.css
+++ b/lib/templates/tailwind.css
@@ -1,3 +1,5 @@
+/* purgecss start ignore */
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
+/* purgecss end ignore */
 @import 'tailwindcss/utilities';


### PR DESCRIPTION
per https://tailwindcss.com/docs/controlling-file-size/ base and components should not be purged.  I found this out the hard way after spending 3h trying to figure out why my local dev env was rendering different css than prod :)