### PR TITLE
feat: `exposeConfig` to reference resolved config in javascript runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can also use CSS comments to tell purgeCSS to ignore some blocks:
 
 ## Referencing in JavaScript
 
-It can often be useful to reference tailwind configuration values in client-side JavaScript — for example to access some of your theme values when dynamically applying inline styles in acomponent.
+It can often be useful to reference tailwind configuration values in runtime. For example to access some of your theme values when dynamically applying inline styles in acomponent.
 
 If you need resolved tailwind config in runtime, you can enable `exposeConfig` option in `nuxt.config`:
 
@@ -99,7 +99,7 @@ If you need resolved tailwind config in runtime, you can enable `exposeConfig` o
 }
 ```
 
-Then import it where needed from `~tailwind.config`:
+Then import where needed from `~tailwind.config`:
 
 ```js
 // Import entire resolved config

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can also use CSS comments to tell purgeCSS to ignore some blocks:
 
 ## Referencing in JavaScript
 
-It can often be useful to reference tailwind configuration values in runtime. For example to access some of your theme values when dynamically applying inline styles in acomponent.
+It can often be useful to reference tailwind configuration values in runtime. For example to access some of your theme values when dynamically applying inline styles in a component.
 
 If you need resolved tailwind config in runtime, you can enable `exposeConfig` option in `nuxt.config`:
 
@@ -102,7 +102,7 @@ If you need resolved tailwind config in runtime, you can enable `exposeConfig` o
 Then import where needed from `~tailwind.config`:
 
 ```js
-// Import entire resolved config
+// Import fully resolved config
 import tailwindConfig from '~tailwind.config'
 
  // Import only part which is required to allow tree-shaking

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ You can also use CSS comments to tell purgeCSS to ignore some blocks:
 /* purgecss end ignore */
 ```
 
-## Access Config in Runtime
+## Referencing in JavaScript
+
+It can often be useful to reference tailwind configuration values in client-side JavaScript — for example to access some of your theme values when dynamically applying inline styles in acomponent.
 
 If you need resolved tailwind config in runtime, you can enable `exposeConfig` option in `nuxt.config`:
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ If you want to set a different path for the configuration file or css file, you 
   tailwindcss: {
     configPath: '~/config/tailwind.config.js',
     cssPath: '~/assets/css/tailwind.css',
-    purgeCSSInDev: false
+    purgeCSSInDev: false,
+    exposeConfig: false
   }
 }
 ```
@@ -82,6 +83,31 @@ You can also use CSS comments to tell purgeCSS to ignore some blocks:
 @import '@snackbar/core/dist/snackbar.css';
 /* purgecss end ignore */
 ```
+
+## Access Config in Runtime
+
+If you need resolved tailwind config in runtime, you can enable `exposeConfig` option in `nuxt.config`:
+
+```js
+// nuxt.config.js
+{
+  tailwindcss: {
+    exposeConfig: true
+  },
+}
+```
+
+Then import it where needed from `~tailwind.config`:
+
+```js
+// Import entire resolved config
+import tailwindConfig from '~tailwind.config'
+
+ // Import only part which is required to allow tree-shaking
+import { theme } from '~tailwind.config'
+```
+
+**NOTE:** Please be aware this adds **~19.5KB (~3.5KB)** to the client bundle size.
 
 ## Development
 

--- a/example/nuxt.config.js
+++ b/example/nuxt.config.js
@@ -5,6 +5,6 @@ module.exports = {
   buildDir: resolve(__dirname, '.nuxt'),
   srcDir: __dirname,
   modules: [
-    { handler: require('../') }
+    [require('../'), { exposeConfig: true }]
   ]
 }

--- a/example/pages/index.vue
+++ b/example/pages/index.vue
@@ -8,6 +8,14 @@
   </div>
 </template>
 
+<script>
+import tailwindConfig from '~tailwind.config'
+
+window.tailwindConfig = tailwindConfig
+
+export default {}
+</script>
+
 <style scoped>
 .banner {
   @apply bg-indigo-900 text-center py-4;

--- a/example/pages/index.vue
+++ b/example/pages/index.vue
@@ -11,7 +11,7 @@
 <script>
 import tailwindConfig from '~tailwind.config'
 
-window.tailwindConfig = tailwindConfig
+global.tailwindConfig = tailwindConfig
 
 export default {}
 </script>

--- a/lib/module.js
+++ b/lib/module.js
@@ -62,15 +62,30 @@ module.exports = async function (moduleOptions) {
     ** https://tailwindcss.com/docs/configuration/#referencing-in-javascript
     */
     if (options.exposeConfig) {
+      // Resolve config
       const tailwindConfig = require(configPath)
       const resolveConfig = require('tailwindcss/resolveConfig')
       const resolvedConfig = resolveConfig(tailwindConfig)
+
+      // Render as a json file in buildDir
       this.addTemplate({
         src: resolve(__dirname, 'templates/tailwind.config.json'),
         fileName: 'tailwind.config.json',
         options: { config: resolvedConfig }
       })
-      this.options.alias['~tailwind.config'] = resolve(this.options.buildDir, 'tailwind.config.json')
+
+      // Alias to ~tailwind.config
+      this.options.alias['~tailwind.config'] =
+        resolve(this.options.buildDir, 'tailwind.config.json')
+
+      // Force chunk creation for long term caching
+      const { cacheGroups } = this.options.build.optimization.splitChunks
+      cacheGroups.tailwindConfig = {
+        test: /tailwind\.config/,
+        chunks: 'all',
+        priority: 10,
+        name: true
+      }
     }
   })
 }

--- a/lib/module.js
+++ b/lib/module.js
@@ -58,8 +58,8 @@ module.exports = async function (moduleOptions) {
     }
 
     /*
-    ** Expose resolved tailwind config to the context
-    **
+    ** Expose resolved tailwind config as an alias
+    ** https://tailwindcss.com/docs/configuration/#referencing-in-javascript
     */
     if (options.exposeConfig) {
       const tailwindConfig = require(configPath)

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,4 +1,4 @@
-const { join } = require('path')
+const { join, resolve } = require('path')
 const { ensureTemplateFile } = require('./utils')
 
 module.exports = async function (moduleOptions) {
@@ -6,6 +6,7 @@ module.exports = async function (moduleOptions) {
     configPath: 'tailwind.config.js',
     cssPath: join(this.options.dir.assets, 'css', 'tailwind.css'),
     purgeCSSInDev: false,
+    exposeConfig: false,
     ...this.options.tailwindcss,
     ...moduleOptions
   }
@@ -54,6 +55,22 @@ module.exports = async function (moduleOptions) {
         ...(this.options.purgeCSS || {})
       }
       await this.requireModule(['nuxt-purgecss', purgeCSS])
+    }
+
+    /*
+    ** Expose resolved tailwind config to the context
+    **
+    */
+    if (options.exposeConfig) {
+      const tailwindConfig = require(configPath)
+      const resolveConfig = require('tailwindcss/resolveConfig')
+      const resolvedConfig = resolveConfig(tailwindConfig)
+      this.addTemplate({
+        src: resolve(__dirname, 'templates/tailwind.config.json'),
+        fileName: 'tailwind.config.json',
+        options: { config: resolvedConfig }
+      })
+      this.options.alias['~tailwind.config'] = resolve(this.options.buildDir, 'tailwind.config.json')
     }
   })
 }

--- a/lib/templates/tailwind.config.json
+++ b/lib/templates/tailwind.config.json
@@ -1,0 +1,1 @@
+<%= JSON.stringify(options.config, null, 2) %>


### PR DESCRIPTION
closes #62

---

It can often be useful to reference tailwind configuration values in runtime. For example to access some of your theme values when dynamically applying inline styles in a component.

If you need resolved tailwind config in runtime, you can enable `exposeConfig` option in `nuxt.config`:

```js
// nuxt.config.js
{
  tailwindcss: {
    exposeConfig: true
  },
}
```

Then import where needed from `~tailwind.config`:

```js
// Import fully resolved config
import tailwindConfig from '~tailwind.config'

 // Import only part which is required to allow tree-shaking
import { theme } from '~tailwind.config'
```

**NOTE:** Please be aware this adds **~19.5KB (~3.5KB)** to the client bundle size.

![image](https://user-images.githubusercontent.com/5158436/76342589-22e77c80-62ff-11ea-858d-54b46c033325.png)
