### PR TITLE
feat: skip insert 'tailwind.css' when config.css option exist

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -13,17 +13,20 @@ module.exports = async function (moduleOptions) {
   const configPath = this.nuxt.resolver.resolveAlias(options.configPath)
   const cssPath = this.nuxt.resolver.resolveAlias(options.cssPath)
 
-  /*
-  ** Generates if not exists:
-  ** - tailwind.config.js
-  ** - @/assets/css/tailwind.css
-  */
-  await ensureTemplateFile(this.options.srcDir, 'tailwind.config.js', configPath)
-  const tailwindCSSExists = await ensureTemplateFile(this.options.srcDir, 'tailwind.css', cssPath)
+  // if nuxt.config.js include 'cssPath'. skip insert 'cssPath' to css option
+  if (this.options.css.some(element => element === cssPath)) {
+    /*
+    ** Generates if not exists:
+    ** - tailwind.config.js
+    ** - @/assets/css/tailwind.css
+    */
+    await ensureTemplateFile(this.options.srcDir, 'tailwind.config.js', configPath)
+    const tailwindCSSExists = await ensureTemplateFile(this.options.srcDir, 'tailwind.css', cssPath)
 
-  // Include CSS file in project css
-  if (tailwindCSSExists) {
-    this.options.css.unshift(cssPath)
+    // Include CSS file in project css
+    if (tailwindCSSExists) {
+      this.options.css.unshift(cssPath)
+    }
   }
 
   // This hooks is called only for `nuxt dev` and `nuxt build` commands


### PR DESCRIPTION
With issue [nuxt config.css priority High than module config](https://github.com/nuxt-community/tailwindcss-module/issues/107)