### PR TITLE
chore: improve purge globs

### DIFF
--- a/lib/files/tailwind.config.js
+++ b/lib/files/tailwind.config.js
@@ -6,14 +6,11 @@ module.exports = ({ dev, rootDir, srcDir }) => ({
     // Learn more on https://tailwindcss.com/docs/controlling-file-size/#removing-unused-css
     enabled: !dev,
     content: [
-      `${srcDir}/components/**/*.vue`,
+      `${srcDir}/components/**/*.{vue,js}`,
       `${srcDir}/layouts/**/*.vue`,
       `${srcDir}/pages/**/*.vue`,
-      `${srcDir}/plugins/**/*.js`,
-      `${rootDir}/nuxt.config.js`,
-      // TypeScript
-      `${srcDir}/plugins/**/*.ts`,
-      `${rootDir}/nuxt.config.ts`
+      `${srcDir}/plugins/**/*.{js,ts}`,
+      `${rootDir}/nuxt.config.{js,ts}`
     ]
   }
 })

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -50,7 +50,7 @@ describe('config', () => {
   })
 
   test('merged the tailwind default config', () => {
-    expect(nuxt.options.build.postcss.plugins.tailwindcss.purge.content).toContain(`${rootDir}/nuxt.config.js`)
+    expect(nuxt.options.build.postcss.plugins.tailwindcss.purge.content).toContain(`${rootDir}/nuxt.config`)
     expect(nuxt.options.build.postcss.plugins.tailwindcss.purge.content).toContain('content/**/*.md')
   })
 })

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -50,7 +50,7 @@ describe('config', () => {
   })
 
   test('merged the tailwind default config', () => {
-    expect(nuxt.options.build.postcss.plugins.tailwindcss.purge.content).toContain(`${rootDir}/nuxt.config`)
+    expect(nuxt.options.build.postcss.plugins.tailwindcss.purge.content).toContain(`${rootDir}/nuxt.config.{js,ts}`)
     expect(nuxt.options.build.postcss.plugins.tailwindcss.purge.content).toContain('content/**/*.md')
   })
 })


### PR DESCRIPTION
1. This PR adds support for purging JS-file based components by default (helpful for small components with render functions)
2. Furthermore, ts and js declarations are grouped together