### PR TITLE
updated readme to make installation foolproof

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@
 
 ```bash
 # Using npm
-npm install --save-dev @nuxtjs/tailwindcss
+npm install --save @nuxtjs/tailwindcss
 # Using yarn
-yarn add --dev @nuxtjs/tailwindcss
+yarn add @nuxtjs/tailwindcss
 ```
 
 2. Add `@nuxtjs/tailwindcss` to the `buildModules` section of `nuxt.config.js`


### PR DESCRIPTION
IMO if this is supposed to be used in production, we should not attempt to prevent that by making it a devDependency. Official advice from #9 suggests not even making it a devDependency. Why woud it be a devDependency if it's also required in production?