### PR TITLE
fix: remove duplicated border-2 class from copy-box

### DIFF
--- a/lib/ui/pages/index.vue
+++ b/lib/ui/pages/index.vue
@@ -15,7 +15,7 @@
       </span>
     </div>
     <div
-      class="copy-box border-2 rounded-md bg_white"
+      class="copy-box rounded-md bg_white"
       :class="boxClasses"
     >
       <span


### PR DESCRIPTION
boxClasses() already implements a border-2 class by default.

Some background as to why this change matters: 

I'm using @nuxtjs/html-validator (https://html-validator.nuxtjs.org/) in a project, and the package is also validating the ./_tailwind colors page, thus giving me a duplicated border-2 class error message on the copy-box div.

As a side question: Is there a way to possibly turn off the generation of the colors via this module?