### PR TITLE
fix(middleware): use cjs syntax

### DIFF
--- a/lib/serverMiddleware/tailwindConfigViewer.js
+++ b/lib/serverMiddleware/tailwindConfigViewer.js
@@ -1,11 +1,11 @@
-import { withoutTrailingSlash, withTrailingSlash } from '@nuxt/ufo'
-import createServer from 'tailwind-config-viewer/server'
+const { withoutTrailingSlash, withTrailingSlash } = require('@nuxt/ufo')
+const createServer = require('tailwind-config-viewer/server')
 
 const server = createServer({
   tailwindConfigProvider: () => process.nuxt ? process.nuxt.$config.tailwind.getConfig() : {}
 }).asMiddleware()
 
-export default (req, res) => {
+module.exports = (req, res) => {
   if (req.originalUrl === withoutTrailingSlash(process.nuxt.$config.tailwind.viewerPath)) {
     res.writeHead(301, { Location: withTrailingSlash(req.originalUrl) })
     res.end()


### PR DESCRIPTION
It is better using CommonJS for module exports to avoid mixing esm/cjs syntaxes in node_modules

resolves #235

