### PR TITLE
fix: correct #247 create tailwind.config.js even if not existing

### DIFF
--- a/example/tailwind.config.js
+++ b/example/tailwind.config.js
@@ -1,15 +1,1 @@
-module.exports = {
-  theme: {},
-  variants: {},
-  plugins: [],
-  purge: {
-    enabled: false,
-    content: [
-      'C:\\Users\\florent\\workdir\\tailwindcss-module\\example/components/**/*.{vue,js}',
-      'C:\\Users\\florent\\workdir\\tailwindcss-module\\example/layouts/**/*.vue',
-      'C:\\Users\\florent\\workdir\\tailwindcss-module\\example/pages/**/*.vue',
-      'C:\\Users\\florent\\workdir\\tailwindcss-module\\example/plugins/**/*.{js,ts}',
-      'C:\\Users\\florent\\workdir\\tailwindcss-module\\example/nuxt.config.{js,ts}'
-    ]
-  }
-}
+module.exports = {}

--- a/example/tailwind.config.js
+++ b/example/tailwind.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  theme: {},
+  variants: {},
+  plugins: [],
+  purge: {
+    enabled: false,
+    content: [
+      'C:\\Users\\florent\\workdir\\tailwindcss-module\\example/components/**/*.{vue,js}',
+      'C:\\Users\\florent\\workdir\\tailwindcss-module\\example/layouts/**/*.vue',
+      'C:\\Users\\florent\\workdir\\tailwindcss-module\\example/pages/**/*.vue',
+      'C:\\Users\\florent\\workdir\\tailwindcss-module\\example/plugins/**/*.{js,ts}',
+      'C:\\Users\\florent\\workdir\\tailwindcss-module\\example/nuxt.config.{js,ts}'
+    ]
+  }
+}

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,9 +1,10 @@
 const { join, resolve, relative } = require('path')
-const { pathExists, createFile } = require('fs-extra')
+const { pathExists, outputFileSync } = require('fs-extra')
 const defu = require('defu')
 const clearModule = require('clear-module')
 const chalk = require('chalk')
 const { joinURL, withTrailingSlash } = require('@nuxt/ufo')
+const { ESLint } = require('eslint')
 
 const logger = require('./logger')
 const defaultTailwindConfig = require('./files/tailwind.config.js')
@@ -36,9 +37,10 @@ module.exports = async function (moduleOptions) {
     tailwindConfig = require(configPath)
     logger.info(`Merging Tailwind config from ~/${relative(this.options.srcDir, configPath)}`)
   } else {
-    // Create one empty tailwind config file by default
-    // If not tailwind config that cause bug to vscode module
-    createFile(configPath)
+    const eslint = new ESLint({ fix: true })
+    outputFileSync(configPath, `module.exports = ${JSON.stringify(options.config, null, 2)}`)
+    const results = await eslint.lintFiles([configPath])
+    await ESLint.outputFixes(results)
   }
   // Merge with our default purgecss default
   tailwindConfig = defu.arrayFn(tailwindConfig, options.config)

--- a/lib/module.js
+++ b/lib/module.js
@@ -4,7 +4,6 @@ const defu = require('defu')
 const clearModule = require('clear-module')
 const chalk = require('chalk')
 const { joinURL, withTrailingSlash } = require('@nuxt/ufo')
-const { ESLint } = require('eslint')
 
 const logger = require('./logger')
 const defaultTailwindConfig = require('./files/tailwind.config.js')
@@ -37,10 +36,7 @@ module.exports = async function (moduleOptions) {
     tailwindConfig = require(configPath)
     logger.info(`Merging Tailwind config from ~/${relative(this.options.srcDir, configPath)}`)
   } else {
-    const eslint = new ESLint({ fix: true })
-    outputFileSync(configPath, `module.exports = ${JSON.stringify(options.config, null, 2)}`)
-    const results = await eslint.lintFiles([configPath])
-    await ESLint.outputFixes(results)
+    outputFileSync(configPath, 'module.exports = {}\n')
   }
   // Merge with our default purgecss default
   tailwindConfig = defu.arrayFn(tailwindConfig, options.config)

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,5 +1,5 @@
 const { join, resolve, relative } = require('path')
-const { pathExists } = require('fs-extra')
+const { pathExists, createFile } = require('fs-extra')
 const defu = require('defu')
 const clearModule = require('clear-module')
 const chalk = require('chalk')
@@ -35,6 +35,10 @@ module.exports = async function (moduleOptions) {
     clearModule(configPath)
     tailwindConfig = require(configPath)
     logger.info(`Merging Tailwind config from ~/${relative(this.options.srcDir, configPath)}`)
+  } else {
+    // Create one empty tailwind config file by default
+    // If not tailwind config that cause bug to vscode module
+    createFile(configPath)
   }
   // Merge with our default purgecss default
   tailwindConfig = defu.arrayFn(tailwindConfig, options.config)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "docs": "nuxt docs/",
     "lint": "eslint --ext .js,.vue example lib test",
     "test": "yarn lint && jest",
+    "jest": "jest",
     "release": "yarn test && standard-version && git push --follow-tags && npm publish"
   },
   "files": [


### PR DESCRIPTION
Maybe I should add 
```
module.exports = {}
```

But at least it creates a tailwind.config.js file even if not existing #247 

In my case it doesn't correct the bug even if the file is created during `nuxt dev` I still have to reload the vscode plugin