### PR TITLE
Fix broken link for Tailwind config

### DIFF
--- a/docs/content/3.options.md
+++ b/docs/content/3.options.md
@@ -117,7 +117,7 @@ export default {
 }
 ```
 
-Learn more about overwriting Tailwind config [here](/tailwind-config).
+Learn more about overwriting Tailwind config [here](/tailwind/config#overwriting-the-configuration).
 
 ## `viewer`
 


### PR DESCRIPTION
Link to "Learn more about overwriting Tailwind config" is broken and should be fixed