### PR TITLE
feat: Update to Tailwind 2.1.2 to natively support jit

### DIFF
--- a/docs/content/2.setup.md
+++ b/docs/content/2.setup.md
@@ -19,55 +19,54 @@ Please make sure to update your Nuxt version to be minimum [v2.15.3](https://git
 <d-code-group>
   <d-code-block label="Yarn" active>
 
-  ```bash
-  yarn upgrade nuxt
-  ```
+```bash
+yarn upgrade nuxt
+```
 
   </d-code-block>
   <d-code-block label="NPM">
 
-  ```bash
-  npm update nuxt
-  ```
+```bash
+npm update nuxt
+```
 
   </d-code-block>
 </d-code-group>
-
 
 ## Installation
 
 1. Add `@nuxtjs/tailwindcss` and `postcss` dependencies to your project:
 
-    <d-code-group>
-      <d-code-block label="Yarn" active>
+   <d-code-group>
+     <d-code-block label="Yarn" active>
 
-      ```bash
-      yarn add --dev @nuxtjs/tailwindcss postcss@latest
-      ```
+   ```bash
+   yarn add --dev @nuxtjs/tailwindcss postcss@latest
+   ```
 
-      </d-code-block>
-      <d-code-block label="NPM">
+     </d-code-block>
+     <d-code-block label="NPM">
 
-      ```bash
-      npm install --save-dev @nuxtjs/tailwindcss postcss@latest
-      ```
+   ```bash
+   npm install --save-dev @nuxtjs/tailwindcss postcss@latest
+   ```
 
-      </d-code-block>
-    </d-code-group>
+     </d-code-block>
+   </d-code-group>
 
 2. Add it to your `buildModules` section in your `nuxt.config.js`:
 
-    ```ts [nuxt.config.js]
-    export default {
-      buildModules: ['@nuxtjs/tailwindcss']
-    }
-    ```
+   ```ts [nuxt.config.js]
+   export default {
+     buildModules: ["@nuxtjs/tailwindcss"]
+   };
+   ```
 
 3. Create your `tailwind.config.js` running:
 
-    ```bash
-    npx tailwindcss init
-    ```
+   ```bash
+   npx tailwindcss init
+   ```
 
 <d-alert type="success">
 
@@ -81,19 +80,20 @@ Discover your color palette based on your Tailwind config with the [Tailwind vie
 
 </d-alert>
 
-
 ## Tailwind Just-In-Time
 
-Tailwind recently released [@tailwindcss/jit](https://github.com/tailwindlabs/tailwindcss-jit) to make the web development much faster.
+Tailwind since version 2.1 introduce the [Just-in-Time Mode (jit)](https://tailwindcss.com/docs/just-in-time-mode) to make the web development much faster.
 
-To activate the option, set `jit: true` in your `nuxt.config.js`:
+To activate the option, set `mode: 'jit'` in your `nuxt.config.js`:
 
 ```ts [nuxt.config.js]
 export default {
   tailwindcss: {
-    jit: true
+    config: {
+      mode: "jit"
+    }
   }
-}
+};
 ```
 
 Restart your Nuxt server and see how fast it is now ⚡️
@@ -124,7 +124,7 @@ export default {
   tailwindcss: {
     // Options
   }
-}
+};
 ```
 
 See the [module options](/options).

--- a/docs/content/2.setup.md
+++ b/docs/content/2.setup.md
@@ -19,54 +19,55 @@ Please make sure to update your Nuxt version to be minimum [v2.15.3](https://git
 <d-code-group>
   <d-code-block label="Yarn" active>
 
-```bash
-yarn upgrade nuxt
-```
+  ```bash
+  yarn upgrade nuxt
+  ```
 
   </d-code-block>
   <d-code-block label="NPM">
 
-```bash
-npm update nuxt
-```
+  ```bash
+  npm update nuxt
+  ```
 
   </d-code-block>
 </d-code-group>
+
 
 ## Installation
 
 1. Add `@nuxtjs/tailwindcss` and `postcss` dependencies to your project:
 
-   <d-code-group>
-     <d-code-block label="Yarn" active>
+    <d-code-group>
+      <d-code-block label="Yarn" active>
 
-   ```bash
-   yarn add --dev @nuxtjs/tailwindcss postcss@latest
-   ```
+      ```bash
+      yarn add --dev @nuxtjs/tailwindcss postcss@latest
+      ```
 
-     </d-code-block>
-     <d-code-block label="NPM">
+      </d-code-block>
+      <d-code-block label="NPM">
 
-   ```bash
-   npm install --save-dev @nuxtjs/tailwindcss postcss@latest
-   ```
+      ```bash
+      npm install --save-dev @nuxtjs/tailwindcss postcss@latest
+      ```
 
-     </d-code-block>
-   </d-code-group>
+      </d-code-block>
+    </d-code-group>
 
 2. Add it to your `buildModules` section in your `nuxt.config.js`:
 
-   ```ts [nuxt.config.js]
-   export default {
-     buildModules: ["@nuxtjs/tailwindcss"]
-   };
-   ```
+    ```ts [nuxt.config.js]
+    export default {
+      buildModules: ['@nuxtjs/tailwindcss']
+    }
+    ```
 
 3. Create your `tailwind.config.js` running:
 
-   ```bash
-   npx tailwindcss init
-   ```
+    ```bash
+    npx tailwindcss init
+    ```
 
 <d-alert type="success">
 
@@ -80,6 +81,7 @@ Discover your color palette based on your Tailwind config with the [Tailwind vie
 
 </d-alert>
 
+
 ## Tailwind Just-In-Time
 
 Tailwind since version 2.1 introduce the [Just-in-Time Mode (jit)](https://tailwindcss.com/docs/just-in-time-mode) to make the web development much faster.
@@ -90,10 +92,10 @@ To activate the option, set `mode: 'jit'` in your `nuxt.config.js`:
 export default {
   tailwindcss: {
     config: {
-      mode: "jit"
+      mode: "jit",
     }
   }
-};
+}
 ```
 
 Restart your Nuxt server and see how fast it is now ⚡️
@@ -124,7 +126,7 @@ export default {
   tailwindcss: {
     // Options
   }
-};
+}
 ```
 
 See the [module options](/options).

--- a/docs/content/3.options.md
+++ b/docs/content/3.options.md
@@ -6,18 +6,16 @@ category: Getting started
 
 > Configure Nuxt Tailwind easily with the tailwindcss property.
 
-
 ```ts [nuxt.config.js]
 export default {
   // Defaults options
   tailwindcss: {
-    cssPath: '~/assets/css/tailwind.css',
-    configPath: 'tailwind.config.js',
-    jit: false,
+    cssPath: "~/assets/css/tailwind.css",
+    configPath: "tailwind.config.js",
     exposeConfig: false,
     config: {}
   }
-}
+};
 ```
 
 ## `cssPath`
@@ -29,9 +27,9 @@ Define the path of the Tailwind CSS file, **if the file exists, it will be impor
 ```ts [nuxt.config.js]
 export default {
   tailwindcss: {
-    cssPath: '~/assets/tailwind.css'
+    cssPath: "~/assets/tailwind.css"
   }
-}
+};
 ```
 
 This file will be directly injected as a [global css](https://nuxtjs.org/guides/configuration-glossary/configuration-css) for Nuxt, it supports `css`, `sass`, `postcss`, and more.
@@ -59,21 +57,9 @@ Example of overwriting the location of the config path:
 ```ts [nuxt.config.js]
 export default {
   tailwindcss: {
-    configPath: '~/config/tailwind.js'
+    configPath: "~/config/tailwind.js"
   }
-}
-```
-
-## `jit`
-
-- Default: `false`
-
-Activate Tailwind Just-In-Time package, learn more on https://github.com/tailwindlabs/tailwindcss-jit
-
-When enabled, you should see this in your console when running `nuxt dev`:
-
-```bash
-ℹ Tailwind JIT activated 
+};
 ```
 
 ## `exposeConfig`
@@ -85,7 +71,7 @@ export default {
   tailwindcss: {
     exposeConfig: true
   }
-}
+};
 ```
 
 Learn more about it in the [Referencing in the application](/tailwind/config#referencing-in-the-application) section.
@@ -108,13 +94,11 @@ export default {
     config: {
       /* Extend the Tailwind config here */
       purge: {
-        content: [
-          'content/**/**.md'
-        ]
+        content: ["content/**/**.md"]
       }
     }
   }
-}
+};
 ```
 
 Learn more about overwriting Tailwind config [here](/tailwind/config#overwriting-the-configuration).
@@ -139,5 +123,5 @@ export default {
   tailwindcss: {
     viewer: false
   }
-}
+};
 ```

--- a/docs/content/3.options.md
+++ b/docs/content/3.options.md
@@ -6,16 +6,17 @@ category: Getting started
 
 > Configure Nuxt Tailwind easily with the tailwindcss property.
 
+
 ```ts [nuxt.config.js]
 export default {
   // Defaults options
   tailwindcss: {
-    cssPath: "~/assets/css/tailwind.css",
-    configPath: "tailwind.config.js",
+    cssPath: '~/assets/css/tailwind.css',
+    configPath: 'tailwind.config.js',
     exposeConfig: false,
     config: {}
   }
-};
+}
 ```
 
 ## `cssPath`
@@ -27,9 +28,9 @@ Define the path of the Tailwind CSS file, **if the file exists, it will be impor
 ```ts [nuxt.config.js]
 export default {
   tailwindcss: {
-    cssPath: "~/assets/tailwind.css"
+    cssPath: '~/assets/tailwind.css'
   }
-};
+}
 ```
 
 This file will be directly injected as a [global css](https://nuxtjs.org/guides/configuration-glossary/configuration-css) for Nuxt, it supports `css`, `sass`, `postcss`, and more.
@@ -57,9 +58,9 @@ Example of overwriting the location of the config path:
 ```ts [nuxt.config.js]
 export default {
   tailwindcss: {
-    configPath: "~/config/tailwind.js"
+    configPath: '~/config/tailwind.js'
   }
-};
+}
 ```
 
 ## `exposeConfig`
@@ -71,7 +72,7 @@ export default {
   tailwindcss: {
     exposeConfig: true
   }
-};
+}
 ```
 
 Learn more about it in the [Referencing in the application](/tailwind/config#referencing-in-the-application) section.
@@ -94,11 +95,13 @@ export default {
     config: {
       /* Extend the Tailwind config here */
       purge: {
-        content: ["content/**/**.md"]
+        content: [
+          'content/**/**.md'
+        ]
       }
     }
   }
-};
+}
 ```
 
 Learn more about overwriting Tailwind config [here](/tailwind/config#overwriting-the-configuration).
@@ -123,5 +126,5 @@ export default {
   tailwindcss: {
     viewer: false
   }
-};
+}
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxtjs/tailwindcss",
-  "version": "4.0.3",
+  "version": "4.1.0",
   "description": "TailwindCSS module for Nuxt",
   "repository": "nuxt-community/tailwindcss-module",
   "license": "MIT",
@@ -25,28 +25,27 @@
   },
   "dependencies": {
     "@nuxt/postcss8": "^1.1.3",
-    "@tailwindcss/jit": "^0.1.18",
     "autoprefixer": "^10.2.5",
-    "chalk": "^4.1.0",
+    "chalk": "^4.1.1",
     "clear-module": "^4.1.1",
     "consola": "^2.15.3",
     "defu": "^3.2.2",
-    "postcss": "^8.2.9",
+    "postcss": "^8.2.13",
     "postcss-custom-properties": "^11.0.0",
     "postcss-nesting": "^7.0.1",
     "tailwind-config-viewer": "^1.5.1",
-    "tailwindcss": "^2.0.4",
-    "ufo": "^0.6.10"
+    "tailwindcss": "^2.1.2",
+    "ufo": "^0.6.11"
   },
   "devDependencies": {
-    "@nuxt/test-utils": "^0.2.1",
+    "@nuxt/test-utils": "^0.2.2",
     "@nuxtjs/eslint-config-typescript": "^6.0.0",
-    "@types/jest": "^26.0.22",
-    "codecov": "^3.8.1",
-    "eslint": "^7.23.0",
+    "@types/jest": "^26.0.23",
+    "codecov": "^3.8.2",
+    "eslint": "^7.25.0",
     "jest": "^26.6.3",
     "nuxt": "^2.15.4",
     "siroc": "^0.8.0",
-    "standard-version": "^9.1.1"
+    "standard-version": "^9.2.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,7 @@ async function tailwindCSSModule (moduleOptions) {
     cssPath: join(nuxt.options.dir.assets, 'css', 'tailwind.css'),
     exposeConfig: false,
     config: defaultTailwindConfig(nuxt.options),
-    viewer: nuxt.options.dev,
-    jit: false
+    viewer: nuxt.options.dev
   })
 
   const configPath = nuxt.resolver.resolveAlias(options.configPath)
@@ -81,13 +80,11 @@ async function tailwindCSSModule (moduleOptions) {
 
     // Add Tailwind PostCSS plugin
     /* istanbul ignore else */
-    if (options.jit !== false) {
-      nuxt.options.build.postcss.plugins['@tailwindcss/jit'] = tailwindConfig
-      logger.info('Tailwind JIT activated')
-    } else {
-      nuxt.options.build.postcss.plugins.tailwindcss = tailwindConfig
-    }
+    nuxt.options.build.postcss.plugins.tailwindcss = tailwindConfig
 
+    if (options.config.mode === 'jit') {
+      logger.info('Tailwind JIT activated')
+    }
     /*
     ** Expose resolved tailwind config as an alias
     ** https://tailwindcss.com/docs/configuration/#referencing-in-javascript

--- a/yarn.lock
+++ b/yarn.lock
@@ -1528,10 +1528,10 @@
     rc9 "^1.2.0"
     std-env "^2.2.1"
 
-"@nuxt/test-utils@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@nuxt/test-utils/-/test-utils-0.2.1.tgz#cc91e1217087d5b78ad8b7acbca16c825dc9d053"
-  integrity sha512-HbkaD4vSGYWOK88O5msmAnVetSyQbecElFWaFnBGDPj5Ua6WegdIpS6n7hRVUXjNRMbORgx0blDESClvTzRcuQ==
+"@nuxt/test-utils@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@nuxt/test-utils/-/test-utils-0.2.2.tgz#c981806b4dfe520e30abe5844316406bf9ff6a91"
+  integrity sha512-dEbYZ9OcMT0oJb1Ot2+ZUSc95JWpYPtKzLUE/x9uFVLxa4ae3WZFQd9n0/n5afAC8stji7UxP/LKn1bVWl41Cw==
   dependencies:
     "@babel/preset-typescript" "^7.13.0"
     consola "^2.15.3"
@@ -1768,21 +1768,6 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@tailwindcss/jit@^0.1.18":
-  version "0.1.18"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/jit/-/jit-0.1.18.tgz#f44ac25b347ad1b4056af4fbda69399070206825"
-  integrity sha512-WNSEiwbggtO9n6+ok2fFdYmhqY20oqLmB82H23nY8P5WzijZbIshojoY3s/OvPD7cmvzkweZ6LLKGWuDS1/vLA==
-  dependencies:
-    chokidar "^3.5.1"
-    dlv "^1.1.3"
-    fast-glob "^3.2.5"
-    lodash.topath "^4.5.2"
-    normalize-path "^3.0.0"
-    object-hash "^2.1.1"
-    parse-glob "^3.0.4"
-    postcss-selector-parser "^6.0.4"
-    quick-lru "^5.1.1"
-
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -1890,10 +1875,10 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^26.0.22":
-  version "26.0.22"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.22.tgz#8308a1debdf1b807aa47be2838acdcd91e88fbe6"
-  integrity sha512-eeWwWjlqxvBxc4oQdkueW5OF/gtfSceKk4OnOAGlUSwS/liBRtZppbJuz1YkgbrbfGOoeBHun9fOvXnjNwrSOw==
+"@types/jest@^26.0.23":
+  version "26.0.23"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.23.tgz#a1b7eab3c503b80451d019efb588ec63522ee4e7"
+  integrity sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==
   dependencies:
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
@@ -2412,11 +2397,6 @@ add-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
   integrity sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=
-
-agent-base@5:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
-  integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
 
 agent-base@6:
   version "6.0.2"
@@ -3343,6 +3323,14 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
@@ -3520,15 +3508,15 @@ coa@^2.0.2:
     chalk "^2.4.1"
     q "^1.1.2"
 
-codecov@^3.8.1:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.8.1.tgz#06fe026b75525ed1ce864d4a34f1010c52c51546"
-  integrity sha512-Qm7ltx1pzLPsliZY81jyaQ80dcNR4/JpcX0IHCIWrHBXgseySqbdbYfkdiXd7o/xmzQpGRVCKGYeTrHUpn6Dcw==
+codecov@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.8.2.tgz#ab24f18783998c39e809ea210af899f8dbcc790e"
+  integrity sha512-6w/kt/xvmPsWMfDFPE/T054txA9RTgcJEw36PNa6MYX+YV29jCHCRFXwbQ3QZBTOgnex1J2WP8bo2AT8TWWz9g==
   dependencies:
     argv "0.0.2"
     ignore-walk "3.0.3"
-    js-yaml "3.14.0"
-    teeny-request "6.0.1"
+    js-yaml "3.14.1"
+    teeny-request "7.0.1"
     urlgrey "0.4.4"
 
 collect-v8-coverage@^1.0.0:
@@ -5027,10 +5015,10 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
-eslint@^7.23.0:
-  version "7.23.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.23.0.tgz#8d029d252f6e8cf45894b4bee08f5493f8e94325"
-  integrity sha512-kqvNVbdkjzpFy0XOszNwjkKzZ+6TcwCQ/h+ozlcIWwaimBBuhlQ4nN6kbiM2L+OjDcznkTJxzYfRFH92sx4a0Q==
+eslint@^7.25.0:
+  version "7.25.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.25.0.tgz#1309e4404d94e676e3e831b3a3ad2b050031eb67"
+  integrity sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==
   dependencies:
     "@babel/code-frame" "7.12.11"
     "@eslint/eslintrc" "^0.4.0"
@@ -6239,12 +6227,12 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-https-proxy-agent@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"
-  integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
   dependencies:
-    agent-base "5"
+    agent-base "6"
     debug "4"
 
 human-signals@^1.1.1:
@@ -7246,15 +7234,7 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@3.14.0:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
-  integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
-js-yaml@^3.13.1:
+js-yaml@3.14.1, js-yaml@^3.13.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -8273,7 +8253,7 @@ node-emoji@^1.8.1:
   dependencies:
     lodash.toarray "^4.4.0"
 
-node-fetch@^2.2.0, node-fetch@^2.6.1:
+node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -9483,7 +9463,7 @@ postcss-modules-values@^4.0.0:
   dependencies:
     icss-utils "^5.0.0"
 
-postcss-nested@^5.0.5:
+postcss-nested@5.0.5:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/postcss-nested/-/postcss-nested-5.0.5.tgz#f0a107d33a9fab11d7637205f5321e27223e3603"
   integrity sha512-GSRXYz5bccobpTzLQZXOnSOfKl6TwVr5CyAQJUPub4nuRJSOECK5AqurxVgmtxP48p0Kc/ndY/YyS1yqldX0Ew==
@@ -9826,10 +9806,10 @@ postcss@^8.1.10, postcss@^8.1.6, postcss@^8.2.1, postcss@^8.2.8:
     nanoid "^3.1.20"
     source-map "^0.6.1"
 
-postcss@^8.2.9:
-  version "8.2.9"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.9.tgz#fd95ff37b5cee55c409b3fdd237296ab4096fba3"
-  integrity sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==
+postcss@^8.2.13:
+  version "8.2.13"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.13.tgz#dbe043e26e3c068e45113b1ed6375d2d37e2129f"
+  integrity sha512-FCE5xLH+hjbzRdpbRb1IMCvPv9yZx2QnDarBEYSN0N0HYk+TcXsEhwdFcFb+SRWOKzKGErhIEbBK2ogyLdTtfQ==
   dependencies:
     colorette "^1.2.2"
     nanoid "^3.1.22"
@@ -11147,10 +11127,10 @@ stackframe@^1.1.1:
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.2.0.tgz#52429492d63c62eb989804c11552e3d22e779303"
   integrity sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==
 
-standard-version@^9.1.1:
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/standard-version/-/standard-version-9.1.1.tgz#7561df6351b075a44544ce3d3ebcffcb9582ba5a"
-  integrity sha512-PF9JnRauBwH7DAkmefYu1mB2Kx0MVG13udqDTFmDUiogbyikBAHBdMrVuauxtAb2YIkyZ3FMYCNv0hqUKMOPww==
+standard-version@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/standard-version/-/standard-version-9.2.0.tgz#d4e64b201ec1abb8a677b265d8755e5e8b9e33a3"
+  integrity sha512-utJcqjk/wR4sePSwDoRcc5CzJ6S+kec5Hd0+1TJI+j1TRYuuptweAnEUdkkjGf2vYoGab2ezefyVtW065HZ1Uw==
   dependencies:
     chalk "^2.4.2"
     conventional-changelog "3.1.24"
@@ -11495,29 +11475,36 @@ tailwind-config-viewer@^1.5.1:
     portfinder "^1.0.26"
     replace-in-file "^6.1.0"
 
-tailwindcss@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-2.0.4.tgz#cf13e62738c3a27065664e449d93b66ee2945506"
-  integrity sha512-WhgR0oiBxGOZ9jY0yVfaJCHnckR7U74Fs/BMsYxGdwGJQ5Hd/HlaKD26bEJFZOvYScJo0QcUj2ImldzedsG7Bw==
+tailwindcss@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-2.1.2.tgz#29402bf73a445faedd03df6d3b177e7b52b7c4a1"
+  integrity sha512-T5t+wwd+/hsOyRw2HJuFuv0LTUm3MUdHm2DJ94GPVgzqwPPFa9XxX0KlwLWupUuiOUj6uiKURCzYPHFcuPch/w==
   dependencies:
     "@fullhuman/postcss-purgecss" "^3.1.3"
     bytes "^3.0.0"
     chalk "^4.1.0"
+    chokidar "^3.5.1"
     color "^3.1.3"
     detective "^5.2.0"
     didyoumean "^1.2.1"
+    dlv "^1.1.3"
+    fast-glob "^3.2.5"
     fs-extra "^9.1.0"
     html-tags "^3.1.0"
     lodash "^4.17.21"
+    lodash.topath "^4.5.2"
     modern-normalize "^1.0.0"
     node-emoji "^1.8.1"
+    normalize-path "^3.0.0"
     object-hash "^2.1.1"
+    parse-glob "^3.0.4"
     postcss-functions "^3"
     postcss-js "^3.0.3"
-    postcss-nested "^5.0.5"
+    postcss-nested "5.0.5"
     postcss-selector-parser "^6.0.4"
     postcss-value-parser "^4.1.0"
     pretty-hrtime "^1.0.3"
+    quick-lru "^5.1.1"
     reduce-css-calc "^2.1.8"
     resolve "^1.20.0"
 
@@ -11538,16 +11525,16 @@ tar@^6.0.2:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
-teeny-request@6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-6.0.1.tgz#9b1f512cef152945827ba7e34f62523a4ce2c5b0"
-  integrity sha512-TAK0c9a00ELOqLrZ49cFxvPVogMUFaWY8dUsQc/0CuQPGF+BOxOQzXfE413BAk2kLomwNplvdtMpeaeGWmoc2g==
+teeny-request@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-7.0.1.tgz#bdd41fdffea5f8fbc0d29392cb47bec4f66b2b4c"
+  integrity sha512-sasJmQ37klOlplL4Ia/786M5YlOcoLGQyq2TE4WHSRupbAuDaQW0PfVxV4MtdBtRJ4ngzS+1qim8zP6Zp35qCw==
   dependencies:
     http-proxy-agent "^4.0.0"
-    https-proxy-agent "^4.0.0"
-    node-fetch "^2.2.0"
+    https-proxy-agent "^5.0.0"
+    node-fetch "^2.6.1"
     stream-events "^1.0.5"
-    uuid "^3.3.2"
+    uuid "^8.0.0"
 
 terminal-link@^2.0.0:
   version "2.1.1"
@@ -11911,6 +11898,11 @@ ufo@^0.6.10:
   resolved "https://registry.yarnpkg.com/ufo/-/ufo-0.6.10.tgz#c7ace9b8f72cb08c35e3a8c8edc76f062fbaa7d0"
   integrity sha512-sMbJnrBcKKsbVyr6++hb0n9lCmrMqkJrNnJIOJ3sckeqY6NMfAULcRGbBWcASSnN1HDV3YqiGCPzi9RVs511bw==
 
+ufo@^0.6.11:
+  version "0.6.11"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-0.6.11.tgz#69311ed4abc8ab671c83754b79ce0d396fea1075"
+  integrity sha512-Yu7TJThwlr23peOkX/+hm6LfkyBs+eDWV880468PTrjKBKjjsNWFFwIuOqDfmXngRo9TZ4+twFYueRH0OLl0Gw==
+
 uglify-js@^3.1.4, uglify-js@^3.5.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.13.1.tgz#2749d4b8b5b7d67460b4a418023ff73c3fefa60a"
@@ -12122,7 +12114,7 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0:
+uuid@^8.0.0, uuid@^8.3.0:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
Hi, everyone!

Since the release of TailwindCSS 2.1 the team supports jit directly in the core project.

So in this PR, the dependencies are updated to the wanted version for the optimal functioning of tailwind and at the same time the `@tailwindcss/jit` dependency is removed as it is not needed for the project.

As the `@tailwindcss/jit` dependency was removed, tailwindcss is added directly to the postcss plugin (`nuxt.options.build.postcss.plugins.tailwindcss = tailwindConfig`). The message in the logger that tailwind jit is activated is maintained, but now verifying that `options.config.mode` is equal to `jit` (this is because when adding the jit mode, tailwind activates it automatically).

Finally the documentation is updated to match the changes made and the package version is bumped to 4.1.0.