### PR TITLE
docs: change jit link since tailwind-jit is now native to tailwindcss

### DIFF
--- a/docs/content/1.index.md
+++ b/docs/content/1.index.md
@@ -12,7 +12,7 @@ This module help you setup [Tailwind CSS](https://tailwindcss.com) (version 2) t
 
 - 👌&nbsp; Zero configuration to start *([see video](https://tailwindcss.nuxtjs.org/#quick-start))*
 - 🗜&nbsp; PurgeCSS included for minimal CSS ⚡️
-- ⚡️&nbsp; Supports [Tailwind Just-In-Time](https://github.com/tailwindlabs/tailwindcss-jit)
+- ⚡️&nbsp; Supports [Tailwind Just-In-Time](https://tailwindcss.com/docs/just-in-time-mode)
 - 🪄&nbsp; Includes [CSS Nesting](https://drafts.csswg.org/css-nesting-1/) with [postcss-nesting](https://github.com/csstools/postcss-nesting)
 - 🎨&nbsp; Discover your Tailwind Colors *([see video](https://tailwindcss.nuxtjs.org/#tailwind-colors))*
 - ⚙️&nbsp; Reference your Tailwind config in your app


### PR DESCRIPTION
Hi there !

Since we updated this module to use the tailwind JIT native implementation we have to change the Tailwindcss' Documentation's link in the documentation 😄 