### PR TITLE
docs: Fix configPath Information

### DIFF
--- a/docs/content/3.options.md
+++ b/docs/content/3.options.md
@@ -63,6 +63,12 @@ export default {
 }
 ```
 
+<d-alert type="info">
+
+If you customized the [`srcDir`](https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-srcdir/) property, you'll have to update `configPath` as `configPath: '~~/tailwind.config.js'` (~~ is the alias for rootDir) for the `tailwind.config.js` to be recognized properly. Read more in the [Issue #114](https://github.com/nuxt-community/tailwindcss-module/issues/114#issuecomment-698885369).
+
+</d-alert>
+
 ## `exposeConfig`
 
 If you need resolved tailwind config in runtime, you can enable exposeConfig option in nuxt.config:
@@ -76,12 +82,6 @@ export default {
 ```
 
 Learn more about it in the [Referencing in the application](/tailwind/config#referencing-in-the-application) section.
-
-<alert type="info">
-
-If you customized the [`srcDir`](https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-srcdir/) property, you'll have to update `configPath` as `configPath: '~~/tailwind.config.js'` (~~ is the alias for rootDir) for the `tailwind.config.js` to be recognized properly. Read more in the [Issue #114](https://github.com/nuxt-community/tailwindcss-module/issues/114#issuecomment-698885369).
-
-</alert>
 
 ## `config`
 


### PR DESCRIPTION
This PR is a revised version of the document added in (#290).
- Use `<d-alert>`.
- Moved information from `exposeConfig` to the `configPath` section.
