### PR TITLE
chore: Resolve deprecation warning from jit

### DIFF
--- a/example/nuxt.config.js
+++ b/example/nuxt.config.js
@@ -8,7 +8,7 @@ export default {
   components: true,
 
   tailwindcss: {
-    jit: true,
+    mode: 'jit',
     exposeConfig: true
   }
 }


### PR DESCRIPTION
```
 WARN  tailwindcss.jit option had been deprecated in favour of tailwind config mode: 'jit'
```

jit mode has been changed. `jit: true` to `mode: 'jit'`
https://tailwindcss.com/docs/just-in-time-mode#enabling-jit-mode