### PR TITLE
docs: Add note about using resolved config with TypeScript

### DIFF
--- a/docs/content/tailwind/1.config.md
+++ b/docs/content/tailwind/1.config.md
@@ -222,6 +222,18 @@ import tailwindConfig from '~tailwind.config'
 import { theme } from '~tailwind.config'
 ```
 
+If you are using TypeScript and want to use the alias to the resolved Tailwind config within your TypeScript files, you will need to add it to your `paths` object within `tsconfig.json`.
+
+```json
+{
+    "paths": {
+      "~tailwind.config": [
+        "./.nuxt/tailwind.config.json" // substitute .nuxt with your build directory
+      ]
+    }
+}
+```
+
 <d-alert type="warning">
 
   Please be aware this adds `~19.5KB` (`~3.5KB`) to the client bundle size.

--- a/docs/content/tailwind/1.config.md
+++ b/docs/content/tailwind/1.config.md
@@ -228,7 +228,7 @@ If you are using TypeScript and want to use the alias to the resolved Tailwind c
 {
     "paths": {
       "~tailwind.config": [
-        "./.nuxt/tailwind.config.json" // substitute .nuxt with your build directory
+        "./.nuxt/tailwind.config.json"
       ]
     }
 }


### PR DESCRIPTION
Ran into a build error using the resolved config with a project today:

`Cannot find module '~tailwind.config' or its corresponding type declarations.`

After reading the [`exposeConfig` PR](https://github.com/nuxt-community/tailwindcss-module/pull/69) I realized it was a missing alias. I hope documenting this can help other people with the same issue. 