### PR TITLE
docs: add missing viewer option

### DIFF
--- a/docs/content/3.options.md
+++ b/docs/content/3.options.md
@@ -16,6 +16,7 @@ export default {
     exposeConfig: false,
     config: {},
     injectPosition: 0,
+    viewer: true,
   }
 }
 ```


### PR DESCRIPTION
Viewer is set to true by default