### PR TITLE
docs: fix brand to `Tailwind CSS`

### DIFF
--- a/docs/content/examples/1.basic.md
+++ b/docs/content/examples/1.basic.md
@@ -6,7 +6,7 @@ fullscreen: true
 
 # Basic Usage Example
 
-> Live example of basic usage of Nuxt TailwindCSS on CodeSandbox.
+> Live example of basic usage of Nuxt Tailwind CSS on CodeSandbox.
 
 Minimal example of a Nuxt project with Tailwind CSS module.
 

--- a/docs/content/examples/2.dark-mode.md
+++ b/docs/content/examples/2.dark-mode.md
@@ -7,7 +7,7 @@ fullscreen: true
 
 # Dark Mode Example
 
-> Live example of dark mode with Nuxt TailwindCSS on CodeSandbox.
+> Live example of dark mode with Nuxt Tailwind CSS on CodeSandbox.
 
 Example with the [tailwindcss-dark-mode](https://github.com/ChanceArthur/tailwindcss-dark-mode) plugin and [@nuxtjs/color-mode](https://github.com/nuxt-community/color-mode-module) module.
 

--- a/docs/content/settings.json
+++ b/docs/content/settings.json
@@ -1,5 +1,5 @@
 {
-  "title": "Nuxt TailwindCSS",
+  "title": "Nuxt Tailwind CSS",
   "url": "https://tailwindcss.nuxtjs.org",
   "logo": {
     "light": "/logo-light.svg",


### PR DESCRIPTION
Let's keep @adamwathan alive a little longer.


<img width="465" alt="Screen Shot 2022-02-03 at 11 37 48" src="https://user-images.githubusercontent.com/741969/152363896-fccf866a-8dc8-458c-b97e-b350ccbf9034.png">

