### PR TITLE
fix: import `tailwindcss/resolveConfig` with extension

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,5 +1,5 @@
 import { defineNuxtConfig } from 'nuxt3'
-import tailwindModule from '..'
+import tailwindModule from '../src/module'
 
 export default defineNuxtConfig({
   // vite: false,

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,5 +1,5 @@
 import { defineNuxtConfig } from 'nuxt3'
-import tailwindModule from '../src/module'
+import tailwindModule from '..'
 
 export default defineNuxtConfig({
   // vite: false,

--- a/src/module.ts
+++ b/src/module.ts
@@ -71,7 +71,7 @@ export default defineNuxtModule({
     // Expose resolved tailwind config as an alias
     // https://tailwindcss.com/docs/configuration/#referencing-in-javascript
     if (moduleOptions.exposeConfig) {
-      const resolveConfig = await import('tailwindcss/resolveConfig').then(r => r.default || r)
+      const resolveConfig = await import('tailwindcss/resolveConfig.js').then(r => r.default || r)
       const resolvedConfig = resolveConfig(tailwindConfig)
       const template = addTemplate({
         filename: 'tailwind.config.mjs',


### PR DESCRIPTION

Resolved issue when upgrading this module from 4.2.0 to 5.0.0-3 in Nuxt2 project and the wrong import path in the nuxt config.

<img width="982" alt="截圖 2022-02-10 下午4 31 14" src="https://user-images.githubusercontent.com/28691559/153372174-2796ca8f-cbef-440b-9199-8fbf92b027f0.png">