### PR TITLE
chore: restore to 4.x version style & fix package.json

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -2,7 +2,7 @@ import { join, relative } from 'path'
 import { existsSync } from 'fs'
 import defu from 'defu'
 import chalk from 'chalk'
-import { withTrailingSlash } from 'ufo'
+import { joinURL, withTrailingSlash } from 'ufo'
 import consola from 'consola'
 import {
   defineNuxtModule,
@@ -124,7 +124,14 @@ export default defineNuxtModule({
         _viewerDevMiddleware(req, res)
       }
       addServerMiddleware({ path, handler: viewerDevMiddleware })
-      nuxt.hook('listen', () => { logger.info(`Tailwind Viewer: ${chalk.underline.yellow(path)}`) })
+      nuxt.hook('listen', (_, listener) => {
+        const url = withTrailingSlash(joinURL(listener.url, path))
+        if (isNuxt2() && !(nuxt.options as any).bridge) {
+          nuxt.options.cli.badgeMessages.push(`Tailwind Viewer: ${chalk.underline.yellow(url)}`)
+        } else {
+          logger.info(`Tailwind Viewer: ${chalk.underline.yellow(url)}`)
+        }
+      })
     }
   }
 })


### PR DESCRIPTION
Sorry for my rudeness. 😢<br />
I made this change because of the tailwind annoying warning when I use nuxt 2 and `@nuxt/tailwindcss` 4.x. <br /><br />
since my own project(and other deps) depends `tailwindcss` 3, which is conflicted with this module,<br /> i got the `The purge/content options have changed in Tailwind CSS v3.0` warning every time i start the dev server.<br />(incorrect `defaultTailwindConfig` causes this)<br /><br /> Then I do upgrade the module to 5.x version which depends `tailwindcss` 3, but it seems not unified with my nuxt 2 as the old ver did. (The tailwind viewer link seems like a local path haha