### PR TITLE
feat: typescript & function support

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -31,7 +31,7 @@ export default defineNuxtModule({
     configKey: 'tailwindcss'
   },
   defaults: nuxt => ({
-    configPath: 'tailwind.config.js',
+    configPath: 'tailwind.config',
     cssPath: join(nuxt.options.dir.assets, 'css/tailwind.css'),
     config: defaultTailwindConfig(nuxt.options),
     viewer: true,
@@ -58,6 +58,9 @@ export default defineNuxtModule({
     let tailwindConfig: any = {}
     if (existsSync(configPath)) {
       tailwindConfig = requireModule(configPath, { clearCache: true })
+      if (typeof tailwindConfig === "function") {
+          tailwindConfig = tailwindConfig(nuxt.options);
+      }
       logger.info(`Merging Tailwind config from ~/${relative(nuxt.options.srcDir, configPath)}`)
       // Transform purge option from Array to object with { content }
       if (Array.isArray(tailwindConfig.purge)) {


### PR DESCRIPTION
I don't see why we can't also have a `tailwind.config.{ts|js}` file with the same functionality as the one in this module.