### PR TITLE
feat: resolve `cssPath` with `resolvePath`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -39,7 +39,7 @@ export default defineNuxtModule({
   }),
   async setup (moduleOptions, nuxt) {
     const configPath = await resolvePath(moduleOptions.configPath)
-    const cssPath = moduleOptions.cssPath && await resolvePath(moduleOptions.cssPath)
+    const cssPath = await resolvePath(moduleOptions.cssPath, { extensions: ['.css', '.sass', '.scss', '.less', '.styl'] })
     const injectPosition = ~~Math.min(moduleOptions.injectPosition, (nuxt.options.css || []).length + 1)
 
     // Include CSS file in project css

--- a/src/module.ts
+++ b/src/module.ts
@@ -9,7 +9,6 @@ import {
   installModule,
   addTemplate,
   addServerMiddleware,
-  resolveAlias,
   requireModule,
   isNuxt2,
   createResolver,
@@ -40,7 +39,7 @@ export default defineNuxtModule({
   }),
   async setup (moduleOptions, nuxt) {
     const configPath = await resolvePath(moduleOptions.configPath)
-    const cssPath = moduleOptions.cssPath && resolveAlias(moduleOptions.cssPath)
+    const cssPath = moduleOptions.cssPath && await resolvePath(moduleOptions.cssPath)
     const injectPosition = ~~Math.min(moduleOptions.injectPosition, (nuxt.options.css || []).length + 1)
 
     // Include CSS file in project css
@@ -49,6 +48,7 @@ export default defineNuxtModule({
         logger.info(`Using Tailwind CSS from ~/${relative(nuxt.options.srcDir, cssPath)}`)
         nuxt.options.css.splice(injectPosition, 0, cssPath)
       } else {
+        logger.info('Using default Tailwind CSS file from runtime/tailwind.css')
         const resolver = createResolver(import.meta.url)
         nuxt.options.css.splice(injectPosition, 0, resolver.resolve('runtime/tailwind.css'))
       }


### PR DESCRIPTION
This change updates the way the `cssPath` option is resolved. Instead of `resolveAlias` it uses `resolvePath` This is the same mechanism used for the resolution of `configPath`. This allows module users to resolve a stylesheet provided by a dependency. In our case, we have a component library that includes a `tailwind.css` file that we would like to share between applications.

## Testing change
- The module playground demonstrates the default behavior works as expected and includes `runtime/tailwind.css`. 
- You can see the module resolve the CSS file from a dependency in the following sandbox where we load only Tailwind's base styles from the tawilwindcss package:
  - https://codesandbox.io/s/gifted-worker-g3lk8j?file=/playground/nuxt.config.ts

You can see annotated results in the screenshot below:

<img width="1923" alt="only-tailwind-base-loaded" src="https://user-images.githubusercontent.com/42922/166146191-88c54498-ca57-45f1-8c3f-319ceda5a539.png">
