### PR TITLE
docs: changed deprecated buildModules to modules

### DIFF
--- a/docs/content/2.setup.md
+++ b/docs/content/2.setup.md
@@ -28,11 +28,11 @@ category: Getting started
       </d-code-block>
     </d-code-group>
 
-2. Add it to your `buildModules` section in your `nuxt.config`:
+2. Add it to your `modules` section in your `nuxt.config`:
 
     ```ts [nuxt.config]
     export default {
-      buildModules: ['@nuxtjs/tailwindcss']
+      modules: ['@nuxtjs/tailwindcss']
     }
     ```
 


### PR DESCRIPTION
@deprecated — This is no longer needed in Nuxt 3 and Nuxt Bridge; all modules should be added to modules instead.