### PR TITLE
feat: support for more semantic injection positions

### DIFF
--- a/docs/content/1.getting-started/2.options.md
+++ b/docs/content/1.getting-started/2.options.md
@@ -83,15 +83,29 @@ Learn more about it in the [Referencing in the application](/tailwind/config#ref
 
 ## `injectPosition`
 
-- Default: `0`
+- Default: `'first'`
 
-You can use any integer to adjust the position of the [global CSS](https://v3.nuxtjs.org/api/configuration/nuxt.config#css) injection, which affects the CSS priority.
+This option lets you adjust the position of the [global CSS](https://v3.nuxtjs.org/api/configuration/nuxt.config#css) injection, which affects the CSS priority. You can use multiple formats to define the position:
+
+* Use `'first'` and `'last'` literals to make Tailwind CSS first or last respectively. First position has the lowest priority, last position overrides everything and hence has the highest priority.
+* Use `{ after: 'some/existing/file.css' } ` to specify the position explicitly.
+* You can use any integer to specify absolute position in the array. This is the most fragile way, as it's easy to forget to adjust it when changing CSS settings.
 
 ```ts [nuxt.config]
 export default {
+  css: [
+    'assets/low-priorty.pcss',
+    'assets/high-priorty.pcss'
+  ],
   tailwindcss: {
-    injectPosition: 0 // equal to nuxt.options.css.unshift(cssPath)
-    // injectPosition: Infinity, // equal to nuxt.options.css.push(cssPath)
+    injectPosition: { 
+        // 'low-priority' will have lower priority than Tailwind stylesheet, 
+        // while 'high-priorty' will override it
+        after: 'assets/low-priorty.pcss'
+    }
+    // injectPosition: 'first'   // equal to nuxt.options.css.unshift(cssPath)
+    // injectPosition: 'last'    // equal to nuxt.options.css.push(cssPath)
+    // injectPosition: 1         // after 'low-priority.pcss'
   }
 }
 ```

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -6,7 +6,8 @@ export default defineNuxtConfig({
     tailwindModule
   ],
   tailwindcss: {
-    exposeConfig: true
+    exposeConfig: true,
+    injectPosition: 'last'
   },
   css: [
     // Including Inter CSS is the first component to reproduce HMR issue. It also causes playground to look better,

--- a/src/module.ts
+++ b/src/module.ts
@@ -90,21 +90,6 @@ export default defineNuxtModule<ModuleOptions>({
       }
     }
 
-    nuxt.options.css = nuxt.options.css ?? []
-    const resolvedNuxtCss = await Promise.all(nuxt.options.css.map(p => resolvePath(p)))
-
-    // Inject only if this file isn't listed already by user (e.g. user may put custom path both here and in css):
-    if (!resolvedNuxtCss.includes(resolvedCss)) {
-      let injectPosition: number
-      try {
-        injectPosition = resolveInjectPosition(nuxt.options.css, moduleOptions.injectPosition)
-      } catch (e) {
-        throw new Error('failed to resolve Tailwind CSS injection position: ' + e.message)
-      }
-
-      nuxt.options.css.splice(injectPosition, 0, resolvedCss)
-    }
-
     // Support `extends` directories
     if (nuxt.options._layers && nuxt.options._layers.length > 1) {
       interface NuxtLayer {
@@ -174,7 +159,6 @@ export default defineNuxtModule<ModuleOptions>({
      */
 
     const cssPath = await resolvePath(moduleOptions.cssPath, { extensions: ['.css', '.sass', '.scss', '.less', '.styl'] })
-    const injectPosition = ~~Math.min(moduleOptions.injectPosition, (nuxt.options.css || []).length + 1)
 
     // Include CSS file in project css
     let resolvedCss: string
@@ -188,10 +172,18 @@ export default defineNuxtModule<ModuleOptions>({
         resolvedCss = createResolver(import.meta.url).resolve('runtime/tailwind.css')
       }
     }
+    nuxt.options.css = nuxt.options.css ?? []
+    const resolvedNuxtCss = await Promise.all(nuxt.options.css.map(p => resolvePath(p)))
 
     // Inject only if this file isn't listed already by user (e.g. user may put custom path both here and in css):
-    const resolvedNuxtCss = await Promise.all(nuxt.options.css.map(p => resolvePath(p)))
     if (!resolvedNuxtCss.includes(resolvedCss)) {
+      let injectPosition: number
+      try {
+        injectPosition = resolveInjectPosition(nuxt.options.css, moduleOptions.injectPosition)
+      } catch (e) {
+        throw new Error('failed to resolve Tailwind CSS injection position: ' + e.message)
+      }
+
       nuxt.options.css.splice(injectPosition, 0, resolvedCss)
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,27 @@
+export type InjectPosition = 'first' | 'last' | number | { after: string };
+
+/** Resolve human-readable inject position specification into absolute index in the array */
+export function resolveInjectPosition (css: string[], position: InjectPosition): number {
+  if (typeof (position) === 'number') {
+    return ~~Math.min(position, css.length + 1)
+  }
+
+  if (typeof (position) === 'string') {
+    switch (position) {
+      case 'first': return 0
+      case 'last': return css.length
+      default: throw new Error('invalid literal: ' + position)
+    }
+  }
+
+  if (position.after !== undefined) {
+    const index = css.indexOf(position.after)
+    if (index === -1) {
+      throw new Error('`after` position specifies a file which does not exists on CSS stack: ' + position.after)
+    }
+
+    return index + 1
+  }
+
+  throw new Error('invalid position: ' + JSON.stringify(position))
+}


### PR DESCRIPTION
Specifying injection position as a simple integer can be both confusing and fragile. It requires you to manually count CSS files, and it's easy to forget about it when changing CSS settings.

This PR adds support for human-readable injection positions, that can be specified as:

* Number, for backward-compatibility
* `'first'` and `'last'` string literals
* `{ after: 'existing-file.css' }` object