### PR TITLE
docs: add editor support section

### DIFF
--- a/docs/content/2.tailwind/3.editor-support.md
+++ b/docs/content/2.tailwind/3.editor-support.md
@@ -1,0 +1,20 @@
+---
+title: Editor Support
+description: Improve your development experience with features such as autocomplete, syntax highlighting, and linting.
+---
+
+Tailwind provides an [extension for Visual Studio Code](https://github.com/tailwindlabs/tailwindcss-intellisense), which enables advanced features such as autocomplete, syntax highlighting, and linting.
+
+There are a few things you need to keep in mind so that the extension works correctly:
+
+1. You need to have a `tailwind.config.js` file in the root of your project, so that the extension gets enabled. You can create the file using `npx tailwindcss init`. The file can have another name, such as `tailwind.config.cjs` in which case you have to configure the extension so that it picks up the new name: https://github.com/tailwindlabs/tailwindcss-intellisense#tailwindcssexperimentalconfigfile.
+
+2. The tailwind configuration file must not have any TypeScript or ESM syntax in the file. That means that you have to use CommonJS exports and can't use a `tailwind.config.ts` file with TypeScript syntax. See https://github.com/tailwindlabs/tailwindcss-intellisense/issues/348#issuecomment-1111313685.
+
+3. Add the following configuration to your `.vscode/settings.json` file, so that Tailwind directives have proper autocomplete, syntax highlighting, and linting:
+
+```json
+"files.associations": {
+	"*.css": "tailwindcss"
+}
+```

--- a/docs/content/2.tailwind/3.editor-support.md
+++ b/docs/content/2.tailwind/3.editor-support.md
@@ -7,13 +7,26 @@ Tailwind provides an [extension for Visual Studio Code](https://github.com/tailw
 
 There are a few things you need to keep in mind so that the extension works correctly:
 
-1. You need to have a `tailwind.config.js` file in the root of your project, so that the extension gets enabled. You can create the file using `npx tailwindcss init`. The file can have another name, such as `tailwind.config.cjs` in which case you have to configure the extension so that it picks up the new name: https://github.com/tailwindlabs/tailwindcss-intellisense#tailwindcssexperimentalconfigfile.
+1. You need to have a `tailwind.config.js` file in the root of your project, so that the extension gets enabled. You can create the file using `npx tailwindcss init`. The file can have another name, such as `tailwind.config.cjs` in which case you have to configure the extension so that it picks up the new name:
+
+```json [.vscode/settings.json]
+"tailwindCSS.experimental.configFile": "tailwind.config.cjs"
+```
+
+If you have multiple Tailwind config files, you can use the array syntax:
+
+```json [.vscode/settings.json]
+"tailwindCSS.experimental.configFile": {
+  "themes/simple/tailwind.config.js": "themes/simple/**",
+  "themes/neon/tailwind.config.js": "themes/neon/**"
+}
+```
 
 2. The tailwind configuration file must not have any TypeScript or ESM syntax in the file. That means that you have to use CommonJS exports and can't use a `tailwind.config.ts` file with TypeScript syntax. See https://github.com/tailwindlabs/tailwindcss-intellisense/issues/348#issuecomment-1111313685.
 
 3. Add the following configuration to your `.vscode/settings.json` file, so that Tailwind directives have proper autocomplete, syntax highlighting, and linting:
 
-```json
+```json [.vscode/settings.json]
 "files.associations": {
 	"*.css": "tailwindcss"
 }


### PR DESCRIPTION
There are a few things to keep in mind when using the official Tailwind Intellisense Extension for VSCode.

I added a guide on how to properly set up the extension to work with @nuxtjs/tailwindcss.