### PR TITLE
fix: remove now-unneeded `@types/tailwindcss`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "@nuxt/kit": "^3.0.0-rc.5",
     "@nuxt/postcss8": "^1.1.3",
-    "@types/tailwindcss": "^3.0.11",
     "autoprefixer": "^10.4.7",
     "chalk": "^5.0.1",
     "clear-module": "^4.1.2",

--- a/src/module.ts
+++ b/src/module.ts
@@ -142,7 +142,7 @@ export default defineNuxtModule<ModuleOptions>({
       })
       addTemplate({
         filename: 'tailwind.config.d.ts',
-        getContents: () => 'declare const config: import("tailwindcss").Config\nexport default config',
+        getContents: () => 'declare const config: import("tailwindcss").Config\nexport { config as default }',
         write: true
       })
       nuxt.options.alias['#tailwind-config'] = template.dst

--- a/src/module.ts
+++ b/src/module.ts
@@ -134,7 +134,7 @@ export default defineNuxtModule<ModuleOptions>({
     // Expose resolved tailwind config as an alias
     // https://tailwindcss.com/docs/configuration/#referencing-in-javascript
     if (moduleOptions.exposeConfig) {
-      const resolveConfig = await import('tailwindcss/resolveConfig.js').then(r => r.default || r) as any
+      const resolveConfig = await import('tailwindcss/resolveConfig.js').then(r => r.default || r)
       const resolvedConfig = resolveConfig(tailwindConfig)
       const template = addTemplate({
         filename: 'tailwind.config.mjs',
@@ -142,7 +142,7 @@ export default defineNuxtModule<ModuleOptions>({
       })
       addTemplate({
         filename: 'tailwind.config.d.ts',
-        getContents: () => 'declare const config: import("tailwindcss/tailwind-config").TailwindConfig\nexport { config as default }',
+        getContents: () => 'declare const config: import("tailwindcss").Config\nexport default config',
         write: true
       })
       nuxt.options.alias['#tailwind-config'] = template.dst

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,13 +908,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/tailwindcss@^3.0.11":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@types/tailwindcss/-/tailwindcss-3.1.0.tgz#1185e4b3437c6e0f19d6cc8cd42738a94fd7b64f"
-  integrity sha512-JxPzrm609hzvF4nmOI3StLjbBEP3WWQxDDJESqR1nh94h7gyyy3XSl0hn5RBMJ9mPudlLjtaXs5YEBtLw7CnPA==
-  dependencies:
-    tailwindcss "*"
-
 "@types/tough-cookie@*":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
@@ -7302,7 +7295,7 @@ tailwind-config-viewer@^1.7.1:
     portfinder "^1.0.26"
     replace-in-file "^6.1.0"
 
-tailwindcss@*, tailwindcss@^3.1.6:
+tailwindcss@^3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.1.6.tgz#bcb719357776c39e6376a8d84e9834b2b19a49f1"
   integrity sha512-7skAOY56erZAFQssT1xkpk+kWt2NrO45kORlxFPXUt3CiGsVPhH1smuH5XoDH6sGPXLyBv+zgCKA2HWBsgCytg==


### PR DESCRIPTION
Tailwindcss types are now included in the core tailwind packge. Thus, separate types package is not needed.

`@types/tailwindcss` is also deprecated by tailwindlabs