### PR TITLE
fix(module): remove prefix for tailwind viewer route on nuxt 2

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -226,7 +226,8 @@ export default defineNuxtModule<ModuleOptions>({
       const route = '/_tailwind'
       const createServer = await import('tailwind-config-viewer/server/index.js').then(r => r.default || r) as any
       const { withTrailingSlash, withoutTrailingSlash } = await import('ufo')
-      const _viewerDevMiddleware = createServer({ tailwindConfigProvider: () => tailwindConfig, routerPrefix: route }).asMiddleware()
+      const routerPrefix = isNuxt3() ? route : undefined
+      const _viewerDevMiddleware = createServer({ tailwindConfigProvider: () => tailwindConfig, routerPrefix }).asMiddleware()
       const viewerDevMiddleware = (req, res) => {
         if (req.originalUrl === withoutTrailingSlash(route)) {
           res.writeHead(301, { Location: withTrailingSlash(req.originalUrl) })


### PR DESCRIPTION
fix bug: #510