### PR TITLE
fix(sources): alias order #tailwindcss/sources

### DIFF
--- a/src/import-css.ts
+++ b/src/import-css.ts
@@ -71,8 +71,8 @@ export default async function importCSS(nuxt = useNuxt()) {
     nuxt.options.css.unshift(file)
   }
 
-  nuxt.options.alias['#tailwindcss'] = file
   nuxt.options.alias['#tailwindcss/sources'] = sourcesTemplate.dst
+  nuxt.options.alias['#tailwindcss'] = file
 
   nuxt.hook('builder:watch', (_e, path) => {
     if (path !== file && projectCSSFiles.includes(path)) {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/tailwindlabs/tailwindcss/issues/18555
https://github.com/nuxt/nuxt/issues/32575

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixed alias resolution order for `#tailwindcss` and `#tailwindcss/sources`.

**Problem:**
When importing `#tailwindcss/sources`, some module resolvers (like Vite) would try to resolve it as `<path-to-#tailwindcss>/sources` instead of using the dedicated alias, resulting in errors like:
```
ENOTDIR: not a directory, open '/path/to/main.css/sources'
```

**Solution:**
Reordered alias definitions to register the more specific `#tailwindcss/sources` before the generic `#tailwindcss` alias. This ensures that the resolver matches the full path first before attempting substring matches.

**Changes:**
- Swapped the order of alias registration in `src/import-css.ts`

